### PR TITLE
fix: support older version of qt quick

### DIFF
--- a/fingeringdiagram.qml
+++ b/fingeringdiagram.qml
@@ -8,7 +8,7 @@
 //
 //  Copyright (c) 2019-2022 Eduardo Rodrigues
 //=============================================================================
-import QtQuick 2.9
+import QtQuick 2.8
 import QtQuick.Dialogs 1.1
 import MuseScore 3.0
 


### PR DESCRIPTION
We will support QtQuick v2.8 which was still used on MuseScore v3.3.